### PR TITLE
HOTFIX: fix .star image path parsing and CTF calculation for ET

### DIFF
--- a/src/ctf.py
+++ b/src/ctf.py
@@ -10,7 +10,7 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
-def compute_ctf(freqs, dfu, dfv, defocus_angle, volt, cs, w, phase_shift=0, b_factor=None):
+def compute_ctf(freqs, dfu, dfv, defocus_angle, volt, cs, w, phase_shift=0, scale_factor=None, b_factor=None):
     """
     Compute the 2D CTF
 
@@ -41,6 +41,8 @@ def compute_ctf(freqs, dfu, dfv, defocus_angle, volt, cs, w, phase_shift=0, b_fa
     df = .5 * (dfu + dfv + (dfu - dfv) * torch.cos(2 * (ang - defocus_angle)))
     gamma = 2 * np.pi * (-.5 * df * lam * s2 + .25 * cs * lam ** 3 * s2 ** 2) - phase_shift
     ctf = (1 - w ** 2) ** .5 * torch.sin(gamma) - w * torch.cos(gamma)
+    if scale_factor is not None:
+        ctf *= scale_factor
     if b_factor is not None:
         ctf *= torch.exp(-b_factor / 4 * s2)
     return ctf

--- a/src/source.py
+++ b/src/source.py
@@ -324,7 +324,7 @@ class _MRCDataFrameSource(ImageSource):
 
         if datadir:
             self.df["__mrc_filepath"] = self.df["__mrc_filename"].apply(
-                lambda filename: os.path.join(datadir, os.path.basename(filename))
+                lambda filename: os.path.join(datadir, filename)
             )
         else:
             self.df["__mrc_filepath"] = self.df["__mrc_filename"]


### PR DESCRIPTION
Small important fixes for drgnai ET ab initio from debugging with @rish-raghu.

1. Treat `_rlnCtfScalefactor` from a .star file as a scale factor (was incorrectly applied as if it were a Gaussian B-factor).
2. Do not truncate image paths (`_rlnImageName`) when parsing a .star file; these paths are typically relative directories from a base RELION directory (`datadir`).