### PR TITLE
fix: use the NumPy product reduction API

### DIFF
--- a/src/fft.py
+++ b/src/fft.py
@@ -41,7 +41,7 @@ def ihtn_center(vol):
     vol = np.fft.ifftshift(vol)
     vol = np.fft.fftn(vol)
     vol = np.fft.fftshift(vol)
-    vol /= np.product(vol.shape)
+    vol /= np.prod(vol.shape)
     return vol.real - vol.imag
 
 

--- a/src/mrc.py
+++ b/src/mrc.py
@@ -124,7 +124,7 @@ class LazyImage:
     def get(self):
         with open(self.fname) as f:
             f.seek(self.offset)
-            image = np.fromfile(f, dtype=self.dtype, count=np.product(self.shape)).reshape(self.shape)
+            image = np.fromfile(f, dtype=self.dtype, count=np.prod(self.shape)).reshape(self.shape)
         return image
 
 


### PR DESCRIPTION
`numpy.prod` is the canonical product reduction. NumPy 2 removed the `numpy.product` alias.

This change replaces `numpy.product` with `numpy.prod` in 2 files.
